### PR TITLE
fix: Admin에 사용자 header 뜨는 이슈 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+
 import { Header } from './components/user/layouts/Header';
 import Home from './components/user/pages/Home';
 import AdminHome from './components/admin/pages/AdminHome';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 
 function App() {
@@ -29,19 +30,24 @@ function App() {
     }
   };
 
+  const location = useLocation();
+  const isAdmin = location.pathname.startsWith('/admin');
+
   return (
     <div className="App">
-      {/* Header 추가 */}
-      <Header
-        isLoggedIn={isLoggedIn}
-        onLoginChange={setIsLoggedIn}
-        onNavigate={handleNavigate}
-        userRole={userRole}
-        onRoleChange={setUserRole}
-      />
+      {/* Home인 경우에만 Header 추가 */}
+      {!isAdmin && (
+        <Header
+          isLoggedIn={isLoggedIn}
+          onLoginChange={setIsLoggedIn}
+          onNavigate={handleNavigate}
+          userRole={userRole}
+          onRoleChange={setUserRole}
+        />
+      )}
 
       {/* 콘텐츠 영역 */}
-      <div style={{ paddingTop: '140px' }}>
+      <div style={{ paddingTop: !isAdmin ? '140px' : '0px' }}>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/admin/*" element={<AdminHome />} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7

## 📝작업 내용

> 사용자 화면 추가되면서 header가 관리자 화면에도 뜨는 이슈가 있어 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 사용자 화면을 구성할 Home 컴포넌트를 만들어서 거기서 padding-top을 추가해주고 Header를 출력해주는 방식은 어떠신가요?
> App.js에서 홈 화면의 라우팅을 구성하게 되면 관리자 페이지 구성도 영향 받을 것 같아 제안드립니다.
>
> 추가로 임포트된 리엑트 라이브러리와 저희가 개별적으로 만드는 컴포넌트를 분리하는 편이 코드 읽기 편할 것 같아서
> import 순서를 조금 손봤습니다.
