### PR TITLE
feat: 랭킹 페이지 추가 - 카테고리 및 랭킹 데이터 조회 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Home from 'pages/Home';
 import MyPage from './pages/MyPage';
 import ProductDetailPage from './pages/ProductDetailPage';
 import ProductListPage from './pages/ProductListPage';
+import RankingPage from './pages/RankingPage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import LogoutPage from './pages/LogoutPage';
@@ -112,6 +113,7 @@ function App() {
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/products/:prdNo" element={<ProductDetailPage />} />
           <Route path="/products" element={<ProductListPage />} />
+          <Route path="/ranking" element={<RankingPage />} />
           <Route path="/admin/*" element={<AdminHome />} />
           <Route path="/login" element={isLoggedIn ? <Navigate to="/" replace /> : <LoginPage />} />
           <Route path="/signup" element={isLoggedIn ? <Navigate to="/" replace /> : <SignupPage />} />

--- a/src/components/common/CategorySelect.js
+++ b/src/components/common/CategorySelect.js
@@ -18,6 +18,7 @@ const CategorySelect = ({ mainCate, subCate, onChange }) => {
       try {
         // 메인 카테고리 조회 (서브 카테고리 정보도 포함되어 있다고 가정)
         const response = await api.get('/api/categories/main');
+        console.log('카테고리 API 응답:', response.data);
         setCategories(response.data || {});
       } catch (error) {
         console.error('카테고리 목록을 불러오는데 실패했습니다:', error);

--- a/src/components/user/layouts/SideSticky.css
+++ b/src/components/user/layouts/SideSticky.css
@@ -2,7 +2,8 @@
 .side-sticky {
   position: fixed;
   top: 180px;
-  right: 20px;
+  left: 50%;
+  margin-left: 670px; /* 1320px(Bootstrap XXL) 기준 절반 660px + 10px 여백 */
   bottom: 30px;
   display: flex;
   flex-direction: column;
@@ -11,26 +12,38 @@
   z-index: 1000;
 }
 
+/* 화면이 좁아서 컨텐츠와 나란히 배치할 공간이 부족하면 우측에 붙인다. */
+/* 670px(중앙~스티키시작) + 90px(스티키너비) + 20px(여유) -> 중앙에서 780px 필요 -> 전체 폭 1560px */
+@media (max-width: 1560px) {
+  .side-sticky {
+    left: auto;
+    margin-left: 0;
+    right: 20px;
+  }
+}
+
 /* 최근 본 상품 카드 기본 레이아웃 */
 .recent-wrapper {
-  width: 120px;
-  background: linear-gradient(180deg, #ffffff 0%, #f0f9ff 100%);
-  border: 1px solid #bae6fd;
-  border-radius: 26px;
-  padding: 16px 10px 12px;
+  width: 90px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 12px 8px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
 }
 
 .recent-wrapper:hover {
   transform: translateY(-2px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
 }
 
 /* 카드가 펼쳐진 뒤에는 하단 패딩을 조정해 카탈로그 영역과 간격을 맞춘다. */
 .recent-wrapper.open {
-  padding-bottom: 10px;
+  padding-bottom: 12px;
 }
 
 /* 카드 헤더 버튼 - 실제 클릭 가능한 영역을 텍스트와 화살표로 한정한다. */
@@ -42,29 +55,25 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   cursor: pointer;
 }
 
 .recent-toggle:focus-visible {
   outline: 2px solid #6cc5ff;
   outline-offset: 3px;
-  border-radius: 18px;
+  border-radius: 8px;
 }
 
 .recent-wrapper.open .recent-toggle {
-  padding-bottom: 12px;
-  margin-bottom: 12px;
-  border-bottom: 1px solid #e0f2fe;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #f1f5f9;
 }
 
 /* 상단 시계 아이콘 - 버튼과 독립적으로 표시되며 hover 영향을 받지 않는다. */
 .recent-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 12px;
-  pointer-events: none;
+  display: none; /* 아이콘 제거하여 심플하게 */
 }
 
 /* 사이드 스티키 전용 원형 아이콘 */
@@ -81,33 +90,35 @@
 
 /* 뱃지 기본 스타일: 장바구니에서만 사용한다. */
 .count-badge {
-  min-width: 20px;
-  height: 20px;
-  padding: 0 6px;
-  border-radius: 999px;
-  background: #bae6fd;
-  color: #2f315a;
-  font-size: 12px;
-  font-weight: 600;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 99px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
   display: flex;
   align-items: center;
   justify-content: center;
+  line-height: 1;
 }
 
 /* 카드 타이틀의 공통 타이포그래피 */
 .sticky-card-title {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
-  color: #2f315a;
+  color: #475569;
+  letter-spacing: -0.3px;
 }
 
 .cart-title {
-  color: inherit;
+  color: #ffffff;
 }
 
 /* 펼침 상태를 표시하는 화살표. 열린 경우 위쪽, 닫힌 경우 아래쪽을 가리킨다. */
 .card-arrow {
-  color: #6cc5ff;
+  color: #94a3b8;
   transition: transform 0.2s ease;
 }
 
@@ -124,11 +135,19 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  max-height: 280px;
+  align-items: center; /* 자식 요소 중앙 정렬 강제 */
+  gap: 8px;
+  max-height: 220px;
   overflow-y: auto;
-  padding-right: 2px;
-  margin-top: 10px;
+  padding: 0 2px;
+  margin-top: 4px;
+  /* 스크롤바 숨기기 (크롬, 사파리, 오페라) */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.recent-catalog::-webkit-scrollbar {
+  display: none;
 }
 
 /* 최근 본 상품 리스트 자체 */
@@ -138,7 +157,9 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0px;
+  align-items: center; /* 리스트 아이템 중앙 정렬 */
+  gap: 8px;
+  width: 100%;
 }
 
 .recent-item {
@@ -152,41 +173,30 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   width: 100%;
   border: none;
   background: transparent;
   padding: 0;
   cursor: pointer;
-  gap: 0;
+  position: relative;
 }
 
-.recent-item-button:hover .recent-title {
-  color: #5ab3ed;
-  text-decoration: underline;
-}
-
-.recent-title {
-  font-size: 12px;
-  color: #475569;
-  text-align: center;
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  line-height: 1.3;
-  word-break: keep-all;
+.recent-item-button:hover .recent-thumb {
+  border-color: #3b82f6;
 }
 
 /* 상품 썸네일 이미지 및 플레이스홀더 */
 .recent-thumb {
-  width: 100px;
-  height: 100px;
-  border-radius: 12px;
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
   object-fit: cover;
-  background: #f9fbff;
-  flex-shrink: 0;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  transition: border-color 0.2s;
+  display: block;
+  margin: 0 auto; /* 이미지 중앙 정렬 확실하게 */
 }
 
 .recent-thumb.placeholder {
@@ -194,34 +204,40 @@
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  color: #8a8fb2;
+  color: #cbd5e1;
+  font-size: 20px;
 }
 
 .recent-empty {
-  margin: 0;
+  margin: 10px 0;
   text-align: center;
-  font-size: 13px;
-  color: #8a8fb2;
+  font-size: 11px;
+  color: #94a3b8;
+  word-break: keep-all;
+  line-height: 1.4;
 }
 
 /* 장바구니 카드 - 사이즈를 최소화하고 상단에 뱃지가 겹치도록 한다. */
 .sticky-card.cart {
-  width: 118px;
+  width: 90px;
   border: none;
-  border-radius: 26px;
-  padding: 12px 10px;
-  background: linear-gradient(135deg, #6cc5ff 0%, #5ab3ed 100%);
+  border-radius: 16px;
+  padding: 12px 8px;
+  background: #6cc5ff; /* 하늘색으로 변경 */
   color: #ffffff;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 6px -1px rgba(108, 197, 255, 0.3);
+  transition: all 0.2s ease;
 }
 
 .sticky-card.cart:hover {
   transform: translateY(-2px);
+  background: #5ab3ed;
+  box-shadow: 0 10px 15px -3px rgba(108, 197, 255, 0.4);
 }
 
 .cart-icon {
@@ -229,44 +245,49 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 4px;
 }
 
 /* 장바구니 숫자 뱃지 위치를 아이콘 우측 상단으로 올린다. */
 .cart-icon .count-badge.cart-badge {
   position: absolute;
-  top: -16px;
-  right: -18px;
-  background: #ff6b6b;
+  top: -12px; /* 위로 더 올림 */
+  right: -16px; /* 오른쪽으로 더 뺌 */
+  background: #ef4444;
   color: #ffffff;
+  border: 2px solid #6cc5ff; /* 뱃지 테두리를 버튼 배경색과 맞춰 자연스럽게 */
 }
 
 .count-badge.cart-badge {
-  background: #ff6b6b;
+  background: #ef4444;
   color: #ffffff;
 }
 
 /* 맨 위로 이동 버튼 - sticky 열 하단에서 살짝 좌측으로 치우치게 배치 */
 .scroll-top-button {
-  width: 46px;
-  height: 46px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  border: 1px solid #bae6fd;
+  border: 1px solid #e2e8f0;
   background: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #5ab3ed;
+  color: #64748b;
   cursor: pointer;
-  transition: transform 0.2s ease;
+  transition: all 0.2s ease;
   margin-top: auto;
   margin-right: 0;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   align-self: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .scroll-top-button:hover {
   transform: translateY(-2px);
-  color: #6cc5ff;
+  color: #3b82f6;
+  border-color: #3b82f6;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 @media (max-width: 1280px) {

--- a/src/components/user/layouts/UserGlobalLayout.js
+++ b/src/components/user/layouts/UserGlobalLayout.js
@@ -45,11 +45,15 @@ const UserGlobalLayout = ({
 
         if (Array.isArray(list)) {
           // SideSticky가 기대하는 포맷(id, title, image)으로 매핑
-          const mappedItems = list.map(item => ({
-            id: item.productId || item.id,
-            title: item.productName || item.name,
-            image: item.imageUrl || item.image,
-          }));
+          const mappedItems = list.map(item => {
+            const imgPath = item.imageUrl || item.image || item.prdImg;
+            return {
+              id: item.productId || item.id,
+              title: item.productName || item.name,
+              image: imgPath ? `${api.defaults.baseURL}/images/product/${imgPath}` : null,
+            };
+          });
+          // 최신순 정렬 (API가 최신순으로 준다고 가정하고 reverse 제거)
           setRecentItems(mappedItems);
         } else {
           setRecentItems([]);

--- a/src/components/user/mypage/RecentViewedProducts.css
+++ b/src/components/user/mypage/RecentViewedProducts.css
@@ -29,7 +29,7 @@
 
 .recent-table-header {
   display: grid;
-  grid-template-columns: 3fr 1fr 1fr 1fr;
+  grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr;
   padding: 12px 0;
   border-top: 2px solid #333;
   border-bottom: 1px solid #eee;
@@ -46,7 +46,7 @@
 
 .recent-item {
   display: grid;
-  grid-template-columns: 3fr 1fr 1fr 1fr;
+  grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr;
   padding: 20px 0;
   border-bottom: 1px solid #f5f5f5;
   align-items: center;
@@ -59,6 +59,7 @@
   gap: 16px;
   text-align: left;
   padding-left: 10px;
+  min-width: 0; /* Flex item shrinking fix */
 }
 
 .item-thumb {
@@ -67,12 +68,15 @@
   border-radius: 8px;
   object-fit: cover;
   background-color: #f9f9f9;
+  flex-shrink: 0; /* Prevent image shrinking */
 }
 
 .item-text {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0; /* Allow text truncation */
+  flex: 1; /* 남은 공간을 모두 차지하도록 설정 */
 }
 
 .item-brand {
@@ -84,6 +88,11 @@
   font-size: 15px;
   font-weight: 600;
   color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  width: 100%; /* 부모 너비에 맞춤 */
 }
 
 .col-price {

--- a/src/components/user/mypage/RecentViewedProducts.js
+++ b/src/components/user/mypage/RecentViewedProducts.js
@@ -62,7 +62,7 @@ const RecentViewedProducts = () => {
                   <span className="normal-price">{item.price.toLocaleString()}원</span>
                 )}
               </div>
-              <div className="col-date">{item.viewedDate}</div>
+              <div className="col-date">{item.viewedDate ? new Date(item.viewedDate).toLocaleDateString() : '-'}</div>
               <div className="col-manage">
                 <button className="btn-cart">장바구니</button>
                 <button

--- a/src/pages/ProductDetailPage.js
+++ b/src/pages/ProductDetailPage.js
@@ -32,11 +32,25 @@ const ProductDetailPage = () => {
 
         // 최근 본 상품 저장 로직 추가
         if (currentUser?.userId && prdNo && productObj?.prdSubCate) {
+          // UI 즉시 업데이트를 위한 상세 정보 구성
+          const productDetails = {
+            id: productObj.prdNo,
+            prdNo: productObj.prdNo,
+            name: productObj.prdName,
+            brand: productObj.prdCompany,
+            price: productObj.prdPrice,
+            salePrice: productObj.salePrice,
+            discount: productObj.discountRate || productObj.discount,
+            image: productObj.prdImg ? `${api.defaults.baseURL}/images/product/${productObj.prdImg}` : null,
+            viewedDate: new Date().toISOString(),
+          };
+
           dispatch(
             saveRecentProduct({
               userId: currentUser.userId,
               prdNo,
               prdSubCate: productObj.prdSubCate,
+              productDetails, // 추가된 파라미터
             }),
           );
         }

--- a/src/pages/RankingPage.css
+++ b/src/pages/RankingPage.css
@@ -1,0 +1,70 @@
+.ranking-page .filter-label {
+  min-width: 80px;
+  font-size: 14px;
+  color: #666;
+}
+
+.ranking-page .filter-options button {
+  font-size: 14px;
+  border: 1px solid transparent;
+}
+
+.ranking-page .filter-options button.btn-light {
+  background-color: #fff;
+  color: #888;
+}
+
+.ranking-page .filter-options button.btn-light:hover {
+  background-color: #f8f9fa;
+  color: #333;
+}
+
+.ranking-page .filter-options button.btn-primary {
+  background-color: #0095f6; /* Adjust to match the blue in the image */
+  border-color: #0095f6;
+}
+
+.ranking-card {
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.ranking-card:hover {
+  transform: translateY(-5px);
+}
+
+.ranking-badge {
+  width: 32px;
+  height: 32px;
+  background-color: #fff;
+  color: #333;
+  font-weight: bold;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px; /* Rounded square as in image */
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1;
+}
+
+.ranking-card img {
+  aspect-ratio: 1;
+  object-fit: cover;
+  background-color: #f8f9fa;
+}
+
+.text-truncate-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: 2.4em; /* Approximate height for 2 lines */
+  line-height: 1.2em;
+}
+
+.price-area .text-primary {
+  color: #0095f6 !important; /* Match the blue color */
+}

--- a/src/pages/RankingPage.js
+++ b/src/pages/RankingPage.js
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../lib/apiClient';
+import { ENDPOINTS } from '../components/user/layouts/headerConstants';
+import './RankingPage.css';
+
+// -------------------------------
+// 카테고리 변환 함수
+// -------------------------------
+function transformCategoryData(data) {
+  if (!data || typeof data !== 'object') return { top: [], tree: [] };
+
+  const source = data.tree || data;
+
+  const keys = Object.keys(source).filter(k => !isNaN(Number(k)));
+  const sortedKeys = keys.sort((a, b) => Number(a) - Number(b));
+
+  const tree = sortedKeys.map(key => {
+    const item = source[key];
+    const title = item.mainStr || item.title || item.name || '';
+
+    const subMap = item.sub || item.subCategories || item.children || {};
+    const subKeys = Object.keys(subMap).filter(k => !isNaN(Number(k)));
+
+    const items = subKeys.map(subKey => {
+      const subItem = subMap[subKey];
+      return {
+        id: Number(subKey),
+        name: subItem?.name || subItem?.title || subItem || '',
+      };
+    });
+
+    return { id: Number(key), title, items };
+  });
+
+  const top = tree.map(t => ({ id: t.id, name: t.title }));
+
+  return { top, tree };
+}
+
+const RankingPage = () => {
+  const navigate = useNavigate();
+
+  // 카테고리 및 랭킹 데이터 상태
+  const [categories, setCategories] = useState([{ id: null, name: '전체' }]);
+  const [selectedCategory, setSelectedCategory] = useState(null);
+  const [rankingList, setRankingList] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  // 피부타입 필터 상태 (UI 전용, 기능은 추후 구현)
+  const [selectedSkinType, setSelectedSkinType] = useState('전체');
+  const skinTypes = ['전체', '건성', '중성', '지성', '복합성', '수부지'];
+
+  // 카테고리 데이터 불러오기
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await api.get(ENDPOINTS.categoryTree || '/api/categories/main');
+        const rawData = response.data?.data || response.data;
+        const { top } = transformCategoryData(rawData);
+        setCategories([{ id: null, name: '전체' }, ...top]);
+      } catch (error) {
+        console.error('카테고리 조회 실패:', error);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  // 랭킹 데이터 불러오기
+  useEffect(() => {
+    const fetchRanking = async () => {
+      setLoading(true);
+      try {
+        const params = { limit: 20 };
+        if (selectedCategory !== null) {
+          params.category = selectedCategory;
+        }
+        // 피부타입 필터는 현재 API 파라미터에서 제외됨
+
+        // 1. 랭킹 리스트 조회
+        const response = await api.get('/api/products/ranking', { params });
+        const initialList = response.data.data || [];
+
+        setRankingList(initialList); // 상세조회 제거 — 랭킹 API의 이미지 URL 그대로 사용
+      } catch (error) {
+        console.error('랭킹 조회 실패:', error);
+        setRankingList([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRanking();
+  }, [selectedCategory]);
+
+  const handleProductClick = id => {
+    navigate(`/products/${id}`);
+  };
+
+  const getImageUrl = img => {
+    if (!img) return '/images/product/no-image.png'; // 기본 이미지
+    return img; // BE에서 완성된 URL 그대로 사용
+  };
+
+  return (
+    <div className="ranking-page container mt-4">
+      <div className="mb-4">
+        <h3 className="fw-bold mb-2">랭킹</h3>
+        <p className="text-muted small mb-0">매일 오전 07시에 랭킹 초기화</p>
+      </div>
+
+      {/* 필터 섹션 */}
+      <div className="filters mb-5">
+        {/* 카테고리 필터 */}
+        <div className="filter-group d-flex align-items-center mb-3">
+          <span className="filter-label fw-bold me-4">카테고리</span>
+          <div className="filter-options d-flex gap-2 overflow-auto">
+            {categories.map(cat => (
+              <button
+                key={cat.id ?? 'all'}
+                className={`btn btn-sm rounded-pill px-3 ${
+                  selectedCategory === cat.id ? 'btn-primary' : 'btn-light text-secondary'
+                }`}
+                onClick={() => {
+                  const newValue = cat.id === null ? null : cat.id;
+                  if (selectedCategory === newValue) return; // 동일 클릭 시 리렌더 방지
+                  setSelectedCategory(newValue);
+                }}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 피부타입 필터 (UI Only) */}
+        <div className="filter-group d-flex align-items-center">
+          <span className="filter-label fw-bold me-4">피부타입별</span>
+          <div className="filter-options d-flex gap-2 flex-wrap">
+            {skinTypes.map(type => (
+              <button
+                key={type}
+                className={`btn btn-sm rounded-pill px-3 ${
+                  selectedSkinType === type ? 'btn-primary' : 'btn-light text-secondary'
+                }`}
+                onClick={() => setSelectedSkinType(type)}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 상품 그리드 */}
+      {loading ? (
+        <div className="text-center py-5">로딩 중...</div>
+      ) : (
+        <div className="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-4">
+          {rankingList.map((product, index) => (
+            <div key={product.prdNo} className="col">
+              <div className="card h-100 border-0 ranking-card" onClick={() => handleProductClick(product.prdNo)}>
+                <div className="position-relative">
+                  {/* 랭킹 뱃지 */}
+                  <div className="ranking-badge position-absolute top-0 start-0 m-3">{index + 1}</div>
+                  {/* 상품 이미지 */}
+                  <img
+                    src={getImageUrl(product.prdImg)}
+                    alt={product.prdName}
+                    className="card-img-top rounded-4"
+                    style={{ width: '300px', height: '300px', objectFit: 'cover' }}
+                    onError={e => {
+                      if (e.target.src.endsWith('/images/product/no-image.png')) return;
+                      e.target.src = '/images/product/no-image.png';
+                    }}
+                  />
+                </div>
+
+                <div className="card-body px-0 pt-3">
+                  <h6 className="card-title fw-bold mb-2 text-truncate-2">{product.prdName}</h6>
+                  <div className="price-area">
+                    <span className="text-primary fw-bold fs-5">{product.prdPrice.toLocaleString()}원</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+          {rankingList.length === 0 && (
+            <div className="col-12 text-center py-5">
+              <p className="text-muted">랭킹 상품이 없습니다.</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RankingPage;


### PR DESCRIPTION
#️⃣연관된 이슈
#79

📝작업 내용
이번 PR에서는 상품 랭킹 페이지 신규 구현과 함께, 사용자 피드백을 반영하여 사이드 스티키 및 최근 본 상품 기능의 UI/UX를 대폭 개선했습니다.

1. 랭킹 페이지 구현
- 페이지 추가: 사용자에게 인기 상품 정보를 제공하는 랭킹 페이지를 구현했습니다.
- 카테고리 필터링: 전체 / 스킨케어 / 맨즈케어 / 선케어 등 카테고리별 랭킹 조회 기능을 추가했습니다.
- API 연동: 백엔드 API를 통해 실시간 랭킹 데이터를 비동기적으로 호출하고, 로딩 처리를 구현했습니다.
- UI 개선: 상품 이미지 경로 이슈를 해결하고, "매일 오전 7시 초기화" 안내 문구를 배치했습니다.

2. 사이드 스티키(Side Sticky) UI/UX 개선
디자인 리뉴얼: 
- 패널 너비를 90px로 축소하여 본문 가림을 최소화했습니다.
- 장바구니 버튼 색상을 하늘색으로 변경하고, 알림 뱃지 위치를 조정하여 가독성을 높였습니다.
- 불필요한 아이콘을 제거하고 심플한 카드 형태로 변경했습니다.
위치 최적화:
- 기존 우측 고정 방식에서 본문 영역 기준(중앙 정렬)으로 변경하여, 와이드 모니터에서도 본문 바로 옆에 위치하도록 개선했습니다.
- 화면이 좁아질 경우 자동으로 우측 끝으로 붙는 반응형 로직을 추가했습니다.
- 정보 제공 강화: 최근 본 상품 이미지 하단에 상품명(말줄임 처리)을 추가하여 식별하기 쉽게 만들었습니다.

3. 최근 본 상품 로직 및 마이페이지 개선
- 동기화 문제 해결: 상품 상세 페이지 진입 시, 새로고침 없이도 사이드 스티키의 목록이 즉시 최신화되도록 Redux 로직을 수정했습니다.
마이페이지 UI 수정:
- 상품명이 길어질 경우 레이아웃(판매가 영역)이 깨지는 문제를 해결했습니다 (CSS Grid/Flex 수정 및 말줄임표 적용).
날짜 표시 형식을 보기 좋게 변경했습니다.


💬리뷰 요구사항(선택)
사이드 스티키 위치: 다양한 해상도에서 사이드 스티키가 본문을 가리지 않고 적절한 위치에 고
정되는지 확인 부탁드립니다.

최근 본 상품 동기화: 상품 상세 페이지에 들어갔다 나왔을 때, 사이드바에 즉시 반영되는지 테스트해주세요.