### PR TITLE
chore: API URL을 환경 변수로 변경 - 로컬 개발 환경에 의존하지 않도록 수정

### DIFF
--- a/src/app/api.js
+++ b/src/app/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // 1. Axios 인스턴스 생성 및 기본 URL 설정
 const api = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: process.env.REACT_APP_API_URL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/components/user/layouts/RecentViewedRecommend.js
+++ b/src/components/user/layouts/RecentViewedRecommend.js
@@ -27,7 +27,7 @@ const RecentViewedRecommend = () => {
     }
 
     axios
-      .get("http://localhost:8080/api/products/list/recent", {
+      .get(`${process.env.REACT_APP_API_URL}/api/products/list/recent`, {
         params: { userId }
       })
       .then(res => {

--- a/src/components/user/layouts/SimilarSkinProducts.js
+++ b/src/components/user/layouts/SimilarSkinProducts.js
@@ -49,7 +49,7 @@ const SimilarSkinProducts = ({ userSkin }) => {
     const loadFallback = async () => {
       try {
         const res = await axios.get(
-          'http://localhost:8080/api/products/list/fallback',
+          `${process.env.REACT_APP_API_URL}/api/products/list/fallback`,
           { params: { limit: 4 } }
         );
         setProducts(convertToCard(res.data.data || []));
@@ -61,7 +61,7 @@ const SimilarSkinProducts = ({ userSkin }) => {
     const loadSkinRecommend = async () => {
       try {
         const res = await axios.get(
-          'http://localhost:8080/api/products/list/skin_type',
+          `${process.env.REACT_APP_API_URL}/api/products/list/skin_type`,
           { params: { limit: 4, skin: Number(userSkin) } }
         );
         setProducts(convertToCard(res.data.data || []));

--- a/src/components/user/layouts/headerConstants.js
+++ b/src/components/user/layouts/headerConstants.js
@@ -11,7 +11,7 @@ export {
 } from '../data/headerMocks';
 
 // 공통 API 루트: .env 없이 개발 시에도 동작하도록 기본값을 둔다.
-export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080';
+export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 // 헤더에서 참조하는 예시 엔드포인트 묶음.
 // 실제 백엔드와 연결할 때는 문자열만 교체하면 된다.

--- a/src/features/config/admConfigSlice.js
+++ b/src/features/config/admConfigSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const admConfigSlice = createSlice({
   name: 'admConfig',
   initialState: {
-    apiBaseUrl: 'http://localhost:8085/api/admin',
+    apiBaseUrl: `${process.env.REACT_APP_ADMIN_API_URL}/api/admin`,
   },
   reducers: {},
 });

--- a/src/features/config/userConfigSlice.js
+++ b/src/features/config/userConfigSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const userConfigSlice = createSlice({
   name: 'userConfig',
   initialState: {
-    apiBaseUrl: 'http://localhost:8080/api',
+    apiBaseUrl: `${process.env.REACT_APP_API_URL}/api`,
   },
   reducers: {},
 });

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -4,7 +4,7 @@ import axios from "axios";
 // Axios 인스턴스 생성
 // ================================
 const api = axios.create({
-  baseURL: "http://localhost:8080",
+  baseURL: process.env.REACT_APP_API_URL,
   withCredentials: true,
   timeout: 10000,
 });
@@ -21,7 +21,7 @@ async function requestTokenRefresh() {
       throw new Error("No refresh token");
     }
 
-    const res = await axios.post("http://localhost:8080/api/auth/refresh", {
+    const res = await api.post("/api/auth/refresh", {
       refreshToken,
       userId,
     });

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -92,7 +92,7 @@ const LoginPage = () => {
   };
 
   const handleKakaoLogin = () => {
-    window.location.href = "http://localhost:8080/auth/kakao/login";
+    window.location.href = `${process.env.REACT_APP_API_URL}/auth/kakao/login`;
   };
 
   return (

--- a/src/pages/SignupPage.js
+++ b/src/pages/SignupPage.js
@@ -173,7 +173,7 @@ const SignupPage = () => {
   };
 
   const handleKakaoSignup = () => {
-    window.location.href = "http://localhost:8080/auth/kakao/login";
+    window.location.href = `${process.env.REACT_APP_API_URL}/auth/kakao/login`;
   };
 
   return (

--- a/src/pages/SkinProfileSetupPage.js
+++ b/src/pages/SkinProfileSetupPage.js
@@ -31,7 +31,7 @@ const SkinProfileSetupPage = () => {
       }
 
       const response = await axios.post(
-        'http://localhost:8080/api/user/skin-profile',
+        `${process.env.REACT_APP_API_URL}/api/user/skin-profile`,
         { skinType: profile.skinType },
         {
           headers: {


### PR DESCRIPTION
기존의 하드코딩된 API URL을 process.env.REACT_APP_API_URL로 변경하여 환경에 따라 유연하게 API를 호출할 수 있도록 개선했습니다.
이로 인해 개발 및 배포 환경에서의 일관성을 높였습니다.

